### PR TITLE
Update README.md (line 45)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Add as many `<a class="github-button">` as you like, then put the `<script>` aft
 ```
 
 ``` html
-<script async defer id="github-bjs" src="https://buttons.github.io/buttons.js"></script>
+<script async="defer" id="github-bjs" src="https://buttons.github.io/buttons.js"></script>
 ```
 
 #### Attributes


### PR DESCRIPTION
Fix Error:
`<script async defer id="github-bjs" src="https://buttons.github.io/buttons.js"></script>`

`<script async="defer" id="github-bjs" src="https://buttons.github.io/buttons.js"></script>`

Description Change:
Attribute name "async" associated with an element type "script" must be followed by the ' = ' character.
Open quote is expected for attribute "async" associated with an element type "script".